### PR TITLE
Add project READMEs

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,55 @@
+# Backend
+
+This directory contains the Express server that powers the meeting-prep workflow. It exposes a single REST endpoint used by the React front‑end to generate a dossier for a LinkedIn contact.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Create a `.env` file and provide the following environment variables:
+   - `ANTHROPIC_API_KEY` – API key for Anthropic Claude.
+   - `PERPLEXITY_API_KEY` – API key for Perplexity Ask.
+   - `PORT` – (optional) port to listen on, default `4000`.
+   - `CORS_ORIGIN` – (optional) allowed origin for CORS, default `*`.
+   - `ANTHROPIC_MODEL` – (optional) Claude model ID to use.
+
+## Running the server
+
+Start the server with:
+```bash
+npm start
+```
+
+For automatic reloads during development use:
+```bash
+npm run dev
+```
+
+The server will log `⚡️  Backend ready on :4000` once it is running (or the port you configured).
+
+## API
+
+### `POST /api/report`
+
+Request body:
+```json
+{
+  "linkedinUrl": "https://www.linkedin.com/in/example",
+  "websiteContent": "Optional extra notes from the person's site"
+}
+```
+
+On success the response looks like:
+```json
+{
+  "status": "complete",
+  "opener": "Ice‑breaker text",
+  "questions": [
+    { "q": "Question text", "why": "Reason" }
+  ]
+}
+```
+
+If a timeout occurs or the input is invalid you will receive an error JSON with an appropriate HTTP status code.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,46 +1,27 @@
-# Getting Started with Create React App
+# Frontend
 
-This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
+This React application provides the user interface for the meeting‑prep tool. Users submit a LinkedIn profile and optional website notes; the app then calls the backend to generate a short dossier.
 
-## Available Scripts
+## Requirements
 
-In the project directory, you can run:
+- Node.js 18 or newer
 
-### `npm start`
+## Setup
 
-Runs the app in the development mode.\
-Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Start the development server:
+   ```bash
+   npm start
+   ```
+   The app will be available at [http://localhost:3000](http://localhost:3000).
 
-The page will reload if you make edits.\
-You will also see any lint errors in the console.
+The frontend expects the backend to run on `http://localhost:4000`. If your backend is hosted elsewhere, update the API URL used in `src/App.tsx`.
 
-### `npm test`
+## Scripts
 
-Launches the test runner in the interactive watch mode.\
-See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
-
-### `npm run build`
-
-Builds the app for production to the `build` folder.\
-It correctly bundles React in production mode and optimizes the build for the best performance.
-
-The build is minified and the filenames include the hashes.\
-Your app is ready to be deployed!
-
-See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
-
-### `npm run eject`
-
-**Note: this is a one-way operation. Once you `eject`, you can’t go back!**
-
-If you aren’t satisfied with the build tool and configuration choices, you can `eject` at any time. This command will remove the single build dependency from your project.
-
-Instead, it will copy all the configuration files and the transitive dependencies (webpack, Babel, ESLint, etc) right into your project so you have full control over them. All of the commands except `eject` will still work, but they will point to the copied scripts so you can tweak them. At this point you’re on your own.
-
-You don’t have to ever use `eject`. The curated feature set is suitable for small and middle deployments, and you shouldn’t feel obligated to use this feature. However we understand that this tool wouldn’t be useful if you couldn’t customize it when you are ready for it.
-
-## Learn More
-
-You can learn more in the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).
-
-To learn React, check out the [React documentation](https://reactjs.org/).
+- `npm test` – run the React test suite.
+- `npm run build` – create an optimized production build in the `build` folder.
+- `npm run eject` – expose the underlying configuration (this is irreversible).


### PR DESCRIPTION
## Summary
- create backend README with environment and API details
- replace the React README with project-specific instructions

## Testing
- `npm test -- --watchAll=false --passWithNoTests` in `frontend`
- `npm run build` in `frontend`
- `npm test` in `backend` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6866b48ab250832ab6428bde2155af99