### PR TITLE
Add streaming via SSE

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -53,3 +53,7 @@ On success the response looks like:
 ```
 
 If a timeout occurs or the input is invalid you will receive an error JSON with an appropriate HTTP status code.
+
+### `GET /api/report/stream`
+
+Streams the report using Server-Sent Events. Pass the same parameters as query string values. Each event contains JSON chunks `{ "text": "..." }` while generating and a final `{ "done": true, "report": { ... } }` object when complete.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -19,6 +19,7 @@ This React application provides the user interface for the meeting‑prep tool. 
    The app will be available at [http://localhost:3000](http://localhost:3000).
 
 The frontend expects the backend to run on `http://localhost:4000`. If your backend is hosted elsewhere, update the API URL used in `src/App.tsx`.
+The app now uses Server-Sent Events to stream progress while the dossier is being generated.
 
 ## Scripts
 


### PR DESCRIPTION
## Summary
- support streaming tokens in `runMeetingPrep`
- expose new `/api/report/stream` endpoint
- display streamed output in the React app
- document streaming API and frontend behavior

## Testing
- `npm install` in `backend`
- `npm install` in `frontend`
- `npm test --silent` in `frontend` *(no tests found)*
- `npm test` in `backend` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6866b51058ac832a882fa8476e9017e8